### PR TITLE
feat: search for dcs or open beta folders as required, add github action to build project on tags

### DIFF
--- a/.github/workflows/wix-desktop.yml
+++ b/.github/workflows/wix-desktop.yml
@@ -1,0 +1,91 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# This workflow will build, test, sign and package a WPF or Windows Forms desktop application
+# built on .NET Core.
+# To learn how to migrate your existing application to .NET Core,
+# refer to https://docs.microsoft.com/en-us/dotnet/desktop-wpf/migration/convert-project-from-net-framework
+#
+# To configure this workflow:
+#
+# 1. Configure environment variables
+# GitHub sets default environment variables for every workflow run.
+# Replace the variables relative to your project in the "env" section below.
+#
+# 2. Signing
+# Generate a signing certificate in the Windows Application
+# Packaging Project or add an existing signing certificate to the project.
+# Next, use PowerShell to encode the .pfx file using Base64 encoding
+# by running the following Powershell script to generate the output string:
+#
+# $pfx_cert = Get-Content '.\SigningCertificate.pfx' -Encoding Byte
+# [System.Convert]::ToBase64String($pfx_cert) | Out-File 'SigningCertificate_Encoded.txt'
+#
+# Open the output file, SigningCertificate_Encoded.txt, and copy the
+# string inside. Then, add the string to the repo as a GitHub secret
+# and name it "Base64_Encoded_Pfx."
+# For more information on how to configure your signing certificate for
+# this workflow, refer to https://github.com/microsoft/github-actions-for-desktop-apps#signing
+#
+# Finally, add the signing certificate password to the repo as a secret and name it "Pfx_Key".
+# See "Build the Windows Application Packaging project" below to see how the secret is used.
+#
+# For more information on GitHub Actions, refer to https://github.com/features/actions
+# For a complete CI/CD sample to get started with GitHub Action workflows for Desktop Applications,
+# refer to https://github.com/microsoft/github-actions-for-desktop-apps
+
+name: WiX Package
+
+on:
+  push: 
+    tags: ['*']
+
+jobs:
+
+  build:
+
+    strategy:
+      matrix:
+        configuration: [Release] # Debug, Release
+
+    runs-on: windows-2019  # For a list of available runner types, refer to
+                             # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
+
+    env:
+      Solution_Name: CoordinateConverter.sln                    # Replace with your solution name, i.e. MyWpfApp.sln.
+      Project_Directory: Installer                              # Replace with the Wap project directory relative to the solution, i.e. MyWpfApp.Package.
+      Project_Path: Installer/Installer.wixproj                 # Replace with the path to your Wap project, i.e. MyWpf.App.Package\MyWpfApp.Package.wapproj.
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        
+    - name: Extract version from tag
+      uses: damienaicheh/extract-version-from-tag-action@v1.1.0
+      
+    # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
+    - name: Setup MSBuild.exe
+      uses: microsoft/setup-msbuild@v1.0.2
+
+    # Restore the application to populate the obj folder with RuntimeIdentifiers
+    - name: Restore the Installer
+      run: msbuild . /t:Restore /p:Configuration=$env:Configuration /p:Platform="Any CPU" /p:RestorePackagesConfig=true
+      env:
+        Configuration: ${{ matrix.configuration }}
+
+    # Create the app package by building wix project
+    - name: Build and Package
+      run: msbuild Installer /t:Build /p:Configuration=$env:Configuration /p:Platform=AnyCPU /p:Version=$env:Major.$env:Minor.$env:Patch
+      env:
+        Configuration: ${{ matrix.configuration }}
+
+    # Upload the MSI package: https://github.com/marketplace/actions/upload-a-build-artifact
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: MSI
+        path: ${{ env.Project_Directory }}\bin\${{matrix.configuration}}\en-US

--- a/Installer/CoordinateConverterComponent.wxs
+++ b/Installer/CoordinateConverterComponent.wxs
@@ -2,7 +2,20 @@
   <Fragment>
     <ComponentGroup Id="CoordinateConverterComponent" Directory="INSTALLFOLDER">
       <Component>
-        <File Id="MainExec" Source="CoordinateConverter.exe" />
+        <File Id="MainExec" Source="CoordinateConverter.exe" KeyPath="true">
+          <Shortcut
+            Id="DesktopShortcut"
+            Directory="DesktopFolder"
+            Name="!(loc.ShortcutName)"
+            Icon="CoordinateConverter.exe"
+            IconIndex="0"
+            WorkingDirectory="INSTALLFOLDER"
+            Show="normal"
+            Advertise="true"
+            >
+            <Icon Id="CoordinateConverter.exe" SourceFile="CoordinateConverter.exe"/>
+          </Shortcut>
+      </File>
       </Component>
       <Component>
         <File Id="MainExecConfig" Source="CoordinateConverter.exe.config" />

--- a/Installer/Folders.wxs
+++ b/Installer/Folders.wxs
@@ -3,6 +3,9 @@
     <StandardDirectory Id="ProgramFiles6432Folder">
       <Directory Id="INSTALLFOLDER" Name="!(bind.Property.ProductName)" />
     </StandardDirectory>
+
+    <StandardDirectory Id="DesktopFolder">
+    </StandardDirectory>
     
     <Property Id="DCS_FOUND_FOLDER" >
       <!-- If both are present, it will prefer steam over open beta -->

--- a/Installer/Folders.wxs
+++ b/Installer/Folders.wxs
@@ -4,16 +4,28 @@
       <Directory Id="INSTALLFOLDER" Name="!(bind.Property.ProductName)" />
     </StandardDirectory>
     
-    <Property Id="USER_FOLDER" >
-      <DirectorySearch Id="userProfileSearch" Depth="0" Path="[%USERPROFILE]" />
+    <Property Id="DCS_FOUND_FOLDER" >
+      <!-- If both are present, it will prefer steam over open beta -->
+      <!-- Search for Open Beta -->
+      <DirectorySearch Id="dcsOpenBeta" Depth="0" Path="[%USERPROFILE]">
+        <DirectorySearch Id="dcsOpenBetaSavedGames" Depth="1" Path="Saved Games">
+          <DirectorySearch Id="dcsOpenBetaFolder" Depth="4" Path="DCS.openbeta" AssignToProperty="true">
+          </DirectorySearch>
+        </DirectorySearch>
+      </DirectorySearch>
+      <!-- Search for Steam -->
+      <DirectorySearch Id="dcsSteam" Depth="0" Path="[%USERPROFILE]">
+        <DirectorySearch Id="dcsSteamSavedGames" Depth="1" Path="Saved Games">
+          <DirectorySearch Id="dcsSteamFolder" Depth="4" Path="DCS" AssignToProperty="true">
+          </DirectorySearch>
+        </DirectorySearch>
+      </DirectorySearch>
     </Property>
 
-    <Directory Id="USER_FOLDER">
-      <Directory Id="SavedGames" Name="Saved Games">
-        <Directory Id="DCSFOLDER" Name="DCS" >
-          <Directory Id="Scripts" Name="Scripts">
-          </Directory>
-        </Directory>
+    <SetDirectory Id="DCSFOLDER" Value="[DCS_FOUND_FOLDER]" Sequence="ui"/>
+    
+    <Directory Id="DCSFOLDER">
+      <Directory Id="Scripts" Name="Scripts">
       </Directory>
     </Directory>
   </Fragment>

--- a/Installer/Installer.wixproj
+++ b/Installer/Installer.wixproj
@@ -1,5 +1,5 @@
 ﻿<Project Sdk="WixToolset.Sdk/4.0.2">
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+  <PropertyGroup>
     <DefineConstants>Version=0.5.13</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/Installer/Installer.wixproj
+++ b/Installer/Installer.wixproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="WixToolset.Sdk/4.0.0">
+﻿<Project Sdk="WixToolset.Sdk/4.0.2">
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <DefineConstants>Version=0.5.12</DefineConstants>
+    <DefineConstants>Version=0.5.13</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="WixToolset.Netfx.wixext" Version="4.0.2" />

--- a/Installer/Package.en-us.wxl
+++ b/Installer/Package.en-us.wxl
@@ -2,7 +2,7 @@
 This file contains the declaration of all the localizable strings.
 -->
 <WixLocalization xmlns="http://wixtoolset.org/schemas/v4/wxl" Culture="en-US">
-
+  <String Id="ShortcutName" Value="Coordinate Converter"/>
   <String Id="DowngradeError" Value="A newer version of [ProductName] is already installed." />
   <String Id="NetRequired" Value="This application requires .NET Framework 4.7.2 or later."/>
   <String Id="FeatureCopyLuaTitle" Value="Copy DCS Communication Scripts"/>

--- a/Installer/SavedGamesComponent.wxs
+++ b/Installer/SavedGamesComponent.wxs
@@ -4,9 +4,7 @@
       <Component Id="CommunicationLua" Guid="1C893E5A-B735-4A43-98F6-F85DB6CD2079">
         <RegistryValue KeyPath="yes" Root="HKCU" Key="SOFTWARE\ACME\CoordinateConverter" Name="DCS_Lua_Installed" Type="integer" Value="1" Action="write" />
         <File Id="CommunicationLuaFile" Source="DCS/Communication/CoordinateConverter.lua" />
-        <RemoveFolder Id="RemoveAppData" On="uninstall" />
         <RemoveFolder Id="RemoveDCSFolder" Directory="DCSFOLDER" On="uninstall" />
-        <RemoveFolder Id="RemoveSavedGames" Directory="SavedGames" On="uninstall" />
       </Component>
     </ComponentGroup>
   </Fragment>


### PR DESCRIPTION
## Changes

- Now should search for `%USERPROFILE%/Saved Games/DCS`, or `%USERPROFILE%/Saved Games/DCS.openbeta`, prefers non open beta.
- Github action will now build the project msi automatically whenever a tag is pushed, the tag major minor and patch are read from the tag. This will not modify the internal version used by `CoordinateConverter`, and will only effect the installer.
- Create desktop shortcut for Coordinate Converter